### PR TITLE
Ensure VBA modules use CRLF endings to import cleanly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.bas text eol=crlf
+*.cls text eol=crlf
+*.frm text eol=crlf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [Unreleased]
+- refactor(outlook-vba): stabilize real-time capture with batched queue processing and hourly recovery scheduler
+- docs(outlook-vba): add setup guide for importing hardened modules
+- chore(outlook-vba): enforce CRLF endings for VBA modules to avoid line continuation import failures

--- a/docs/outlook_vba_setup.md
+++ b/docs/outlook_vba_setup.md
@@ -1,0 +1,64 @@
+# HVDC Outlook VBA Automation Setup
+
+## Overview
+
+This package delivers hardened Outlook VBA automation for the HVDC email capture pipeline. It exports every incoming message as `.msg`, preserves attachments, and emits JSON sidecars for downstream ingestion. The automation runs in real time with hourly catch-up protection and structured logging.
+
+## Prerequisites
+
+- Outlook LTSC 2021 on Windows 11 Enterprise
+- Macro security configured for signed code or trusted location
+- Access to the Windows account that will run Outlook continuously
+- Write permissions to `%LOCALAPPDATA%\HVDC`
+
+## Import Instructions
+
+1. Launch Outlook with macros enabled.
+2. Press `ALT+F11` to open the VBA editor.
+3. In the Project pane, remove previous HVDC modules if present.
+4. Choose **File → Import File…** and import each module/class from `outlook_vba`:
+   - `Modules/modHVDC_Config.bas`
+   - `Modules/modHVDC_FileIO.bas`
+   - `Modules/modHVDC_Logging.bas`
+   - `Modules/modHVDC_Export.bas`
+   - `Classes/clsHVDC_InboxWatcher.cls`
+   - `ThisOutlookSession.cls` (overwrite the existing `ThisOutlookSession` code)
+5. Save the VBA project (`ALT+F S`).
+
+## Macro Security
+
+- Prefer signed VBA projects. If signatures are not available, add `%LOCALAPPDATA%\Microsoft\Outlook` to the trusted locations list and store the VBA project there.
+- Confirm that **Trust access to the VBA project object model** is enabled.
+
+## First-Run Checklist
+
+1. Execute `InitializeHVDC` from the VBA Immediate window (`Ctrl+G`) to provision folders, logging, the processed cache, and hidden tasks.
+2. Restart Outlook to ensure `Application_Startup` wires all watchers.
+3. Send a test message to the monitored Inbox and verify that:
+   - `.msg` and `.json` files appear in `%LOCALAPPDATA%\HVDC\exports\YYYY\MM\DD`.
+   - Attachments are written under `...\attachments\<EntryID>`.
+   - Logs are written to `%LOCALAPPDATA%\HVDC\logs\hvdc_pipeline.log`.
+4. Inspect `%LOCALAPPDATA%\HVDC\state\catchup_checkpoint.json` for the initialized timestamp.
+
+## Configuration Notes
+
+- To watch additional folders under Inbox, edit `ADDITIONAL_FOLDERS` in `modHVDC_Config`. Separate multiple entries with `|` (example: `"Inbox\\Operations|Inbox\\Escalations"`).
+- Adjust batching or throttling via `DEFAULT_BATCH_SIZE` and `DEFAULT_QUEUE_INTERVAL_SECONDS` constants in `modHVDC_Config`.
+- Logs rotate automatically at ~10 MB across five files.
+
+## Operational Guidance
+
+- Hourly resilience: A hidden task named **HVDC Hourly Tick** drives the catch-up enumerator. Do not delete this task.
+- Real-time queue: A hidden task named **HVDC Queue Pulse** schedules batched processing without blocking the UI.
+- To reset the processed cache, delete `%LOCALAPPDATA%\HVDC\state\processed_index.json` and run `InitializeHVDC` again.
+
+## Support
+
+- Logs are JSON lines and include metrics per batch.
+- Failures are non-modal; investigate the latest log file for diagnostic context.
+- For disaster recovery, re-run `InitializeHVDC` and relaunch Outlook.
+
+
+## Troubleshooting
+
+- **"Too many line continuations" when importing modules**: Ensure the files retain Windows line endings. Clone or unzip the repository on Windows, or convert the `.bas/.cls` files to `CRLF` before import (the repository now enforces this automatically via `.gitattributes`).

--- a/outlook_vba/Classes/clsHVDC_InboxWatcher.cls
+++ b/outlook_vba/Classes/clsHVDC_InboxWatcher.cls
@@ -1,0 +1,160 @@
+VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = "clsHVDC_InboxWatcher"
+Option Explicit
+
+Private WithEvents m_items As Outlook.Items
+Attribute m_items.VB_VarHelpID = -1
+Private m_queue As Collection
+Private m_folder As Outlook.MAPIFolder
+Private m_folderPath As String
+Private m_storeId As String
+Private m_pendingIndex As Object
+
+Public Sub Initialise(ByVal targetFolder As Outlook.MAPIFolder)
+    On Error GoTo CleanFail
+    Set m_folder = targetFolder
+    Set m_items = targetFolder.Items
+    Set m_queue = New Collection
+    m_folderPath = targetFolder.FolderPath
+    m_storeId = targetFolder.StoreID
+    Set m_pendingIndex = CreateObject("Scripting.Dictionary")
+    m_pendingIndex.CompareMode = vbTextCompare
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "InboxWatcher.Initialise", Err, targetFolder.Name
+End Sub
+
+Public Sub NotifyEntry(ByVal entryId As String)
+    On Error GoTo CleanFail
+    If Len(Trim$(entryId)) = 0 Then
+        Exit Sub
+    End If
+    EnqueueEntry entryId
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "InboxWatcher.NotifyEntry", Err, m_folderPath
+End Sub
+
+Public Sub FlushPending(ByRef stats As HVDCBatchStats)
+    On Error GoTo CleanFail
+    Do While m_queue.Count > 0
+        ProcessPending stats, modHVDC_Config.BatchSizeLimit
+    Loop
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "InboxWatcher.FlushPending", Err, m_folderPath
+End Sub
+
+Public Function HasPending() As Boolean
+    If m_queue Is Nothing Then
+        HasPending = False
+    Else
+        HasPending = (m_queue.Count > 0)
+    End If
+End Function
+
+Public Sub ProcessPending(ByRef stats As HVDCBatchStats, ByVal limit As Long)
+    On Error GoTo CleanFail
+    If m_queue Is Nothing Then Exit Sub
+    Dim processed As Long
+    processed = 0
+    Do While m_queue.Count > 0 And processed < limit
+        Dim entryId As String
+        entryId = CStr(m_queue(1))
+        m_queue.Remove 1
+        ProcessEntry entryId, stats
+        processed = processed + 1
+        If processed Mod 5 = 0 Then
+            DoEvents
+        End If
+    Loop
+    If m_queue.Count > 0 Then
+        modHVDC_Config.RequestQueuePulse
+    End If
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "InboxWatcher.ProcessPending", Err, m_folderPath
+End Sub
+
+Private Sub ProcessEntry(ByVal entryId As String, ByRef stats As HVDCBatchStats)
+    On Error GoTo CleanFail
+    Dim session As Outlook.NameSpace
+    Set session = Application.Session
+    Dim mail As Outlook.MailItem
+    If Len(m_storeId) > 0 Then
+        Set mail = session.GetItemFromID(entryId, m_storeId)
+    Else
+        Set mail = session.GetItemFromID(entryId)
+    End If
+    If Not mail Is Nothing Then
+        modHVDC_Export.ProcessMailItem mail, stats
+        If Not m_pendingIndex Is Nothing Then
+            If m_pendingIndex.Exists(entryId) Then
+                m_pendingIndex.Remove entryId
+            End If
+        End If
+        Set mail = Nothing
+    Else
+        stats.ProcessedCount = stats.ProcessedCount + 1
+        stats.SkippedCount = stats.SkippedCount + 1
+    End If
+    If Not m_pendingIndex Is Nothing Then
+        If m_pendingIndex.Exists(entryId) Then
+            m_pendingIndex.Remove entryId
+        End If
+    End If
+    Exit Sub
+CleanFail:
+    stats.ErrorCount = stats.ErrorCount + 1
+    If Not m_pendingIndex Is Nothing Then
+        If m_pendingIndex.Exists(entryId) Then
+            m_pendingIndex.Remove entryId
+        End If
+    End If
+    modHVDC_Logging.LogException "InboxWatcher.ProcessEntry", Err, entryId
+End Sub
+
+Private Sub EnqueueEntry(ByVal entryId As String)
+    On Error GoTo CleanFail
+    If m_queue Is Nothing Then
+        Set m_queue = New Collection
+    End If
+    If m_pendingIndex Is Nothing Then
+        Set m_pendingIndex = CreateObject("Scripting.Dictionary")
+        m_pendingIndex.CompareMode = vbTextCompare
+    End If
+    If m_pendingIndex.Exists(entryId) Then
+        Exit Sub
+    End If
+    m_queue.Add entryId
+    m_pendingIndex.Add entryId, True
+    modHVDC_Config.RequestQueuePulse
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "InboxWatcher.EnqueueEntry", Err, entryId
+End Sub
+
+Private Sub m_items_ItemAdd(ByVal Item As Object)
+    On Error GoTo CleanFail
+    If TypeOf Item Is Outlook.MailItem Then
+        Dim mail As Outlook.MailItem
+        Set mail = Item
+        EnqueueEntry mail.EntryID
+        Set mail = Nothing
+    End If
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "InboxWatcher.ItemAdd", Err, m_folderPath
+End Sub
+
+Private Sub Class_Terminate()
+    On Error Resume Next
+    Set m_items = Nothing
+    Set m_folder = Nothing
+    Set m_queue = Nothing
+    Set m_pendingIndex = Nothing
+End Sub
+

--- a/outlook_vba/Modules/modHVDC_Config.bas
+++ b/outlook_vba/Modules/modHVDC_Config.bas
@@ -1,0 +1,354 @@
+Attribute VB_Name = "modHVDC_Config"
+Option Explicit
+
+Private Const LOG_MAX_SIZE_BYTES As Long = 10485760 '10 MB
+Private Const LOG_FILE_COUNT As Long = 5
+Private Const DEFAULT_BATCH_SIZE As Long = 25
+Private Const DEFAULT_QUEUE_INTERVAL_SECONDS As Long = 30
+Private Const HOURLY_TASK_NAME As String = "HVDC Hourly Tick"
+Private Const QUEUE_TASK_NAME As String = "HVDC Queue Pulse"
+Private Const CONFIG_FOLDER_NAME As String = "HVDC"
+Private Const EXPORT_FOLDER_NAME As String = "exports"
+Private Const LOG_FOLDER_NAME As String = "logs"
+Private Const STATE_FOLDER_NAME As String = "state"
+Private Const CHECKPOINT_FILE_NAME As String = "catchup_checkpoint.json"
+Private Const PROCESSED_CACHE_NAME As String = "processed_index.json"
+Private Const ADDITIONAL_FOLDERS As String = "" 'Example: "Inbox\\HVDC Alerts|Inbox\\Operations"
+
+Private m_nextQueuePulse As Date
+Private m_processedCache As Object
+
+Public Function LogMaxSizeBytes() As Long
+    LogMaxSizeBytes = LOG_MAX_SIZE_BYTES
+End Function
+
+Public Function LogFileLimit() As Long
+    LogFileLimit = LOG_FILE_COUNT
+End Function
+
+Public Function BatchSizeLimit() As Long
+    BatchSizeLimit = DEFAULT_BATCH_SIZE
+End Function
+
+Public Function QueueIntervalSeconds() As Long
+    QueueIntervalSeconds = DEFAULT_QUEUE_INTERVAL_SECONDS
+End Function
+
+Public Function HourlyTaskName() As String
+    HourlyTaskName = HOURLY_TASK_NAME
+End Function
+
+Public Function QueueTaskName() As String
+    QueueTaskName = QUEUE_TASK_NAME
+End Function
+
+Public Function HVDCBasePath() As String
+    Dim basePath As String
+    basePath = Trim$(Environ$("LOCALAPPDATA"))
+    If Len(basePath) = 0 Then
+        basePath = Trim$(Environ$("USERPROFILE"))
+    End If
+    If Len(basePath) = 0 Then
+        basePath = "C:\\HVDC"
+    End If
+    HVDCBasePath = modHVDC_FileIO.JoinPath(basePath, CONFIG_FOLDER_NAME)
+End Function
+
+Public Function HVDCExportRoot() As String
+    HVDCExportRoot = modHVDC_FileIO.JoinPath(HVDCBasePath(), EXPORT_FOLDER_NAME)
+End Function
+
+Public Function HVDCLogPath() As String
+    HVDCLogPath = modHVDC_FileIO.JoinPath(HVDCBasePath(), LOG_FOLDER_NAME)
+End Function
+
+Public Function HVDCStatePath() As String
+    HVDCStatePath = modHVDC_FileIO.JoinPath(HVDCBasePath(), STATE_FOLDER_NAME)
+End Function
+
+Public Function HVDCCheckpointFile() As String
+    HVDCCheckpointFile = modHVDC_FileIO.JoinPath(HVDCStatePath(), CHECKPOINT_FILE_NAME)
+End Function
+
+Public Function HVDCProcessedCacheFile() As String
+    HVDCProcessedCacheFile = modHVDC_FileIO.JoinPath(HVDCStatePath(), PROCESSED_CACHE_NAME)
+End Function
+
+Public Function HVDCProcessedCache() As Object
+    If m_processedCache Is Nothing Then
+        Set m_processedCache = CreateObject("Scripting.Dictionary")
+        m_processedCache.CompareMode = vbTextCompare
+    End If
+    Set HVDCProcessedCache = m_processedCache
+End Function
+
+Public Sub ResetProcessedCache()
+    If Not m_processedCache Is Nothing Then
+        m_processedCache.RemoveAll
+    End If
+End Sub
+
+Public Function LoggingEnabled() As Boolean
+    LoggingEnabled = True
+End Function
+
+Public Sub InitializeHVDC()
+    On Error GoTo CleanFail
+    EnsureHVDCInfrastructure
+    EnsureReminderTasks
+    modHVDC_FileIO.LoadProcessedCache HVDCProcessedCache
+    modHVDC_FileIO.EnsureCheckpointFile HVDCCheckpointFile
+    RequestQueuePulse
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "InitializeHVDC", Err, ""
+End Sub
+
+Public Sub EnsureHVDCInfrastructure()
+    On Error GoTo CleanFail
+    modHVDC_FileIO.EnsureFolderExists HVDCBasePath
+    modHVDC_FileIO.EnsureFolderExists HVDCExportRoot
+    modHVDC_FileIO.EnsureFolderExists HVDCLogPath
+    modHVDC_FileIO.EnsureFolderExists HVDCStatePath
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "EnsureHVDCInfrastructure", Err, ""
+End Sub
+
+Public Sub EnsureReminderTasks()
+    On Error GoTo CleanFail
+    EnsureHiddenTask HourlyTaskName, True
+    EnsureHiddenTask QueueTaskName, False
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "EnsureReminderTasks", Err, ""
+End Sub
+
+Private Sub EnsureHiddenTask(ByVal taskName As String, ByVal isRecurringHourly As Boolean)
+    On Error GoTo CleanFail
+    Dim session As Outlook.NameSpace
+    Set session = Application.Session
+    Dim tasksFolder As Outlook.MAPIFolder
+    Set tasksFolder = session.GetDefaultFolder(olFolderTasks)
+
+    Dim items As Outlook.Items
+    Set items = tasksFolder.Items
+
+    Dim task As Outlook.TaskItem
+    Dim index As Long
+    For index = 1 To items.Count
+        If TypeOf items(index) Is Outlook.TaskItem Then
+            Set task = items(index)
+            If StrComp(task.Subject, taskName, vbTextCompare) = 0 Then
+                Exit For
+            Else
+                Set task = Nothing
+            End If
+        End If
+    Next index
+
+    If task Is Nothing Then
+        Set task = items.Add(olTaskItem)
+        With task
+            .Subject = taskName
+            .Categories = "HVDC Hidden"
+            .ReminderSet = True
+            .ReminderOverrideDefault = True
+            .ReminderPlaySound = False
+            .ReminderSoundFile = ""
+            .BusyStatus = olFree
+            .Importance = olImportanceLow
+            .Sensitivity = olConfidential
+            .Body = "HVDC automation support item. Do not delete."
+            .ReminderSet = True
+            If isRecurringHourly Then
+                .ReminderTime = DateAdd("h", 1, Now)
+            Else
+                .ReminderTime = Now + (QueueIntervalSeconds / 86400#)
+            End If
+            .Save
+        End With
+    End If
+
+    If isRecurringHourly Then
+        Dim pattern As Outlook.RecurrencePattern
+        Set pattern = task.GetRecurrencePattern
+        With pattern
+            .RecurrenceType = olRecursHourly
+            .Interval = 1
+            .PatternStartDate = Date
+            .Occurrences = 0
+        End With
+        If task.ReminderTime < Now Then
+            task.ReminderTime = DateAdd("h", 1, Now)
+        End If
+    Else
+        If task.ReminderTime < Now Then
+            task.ReminderTime = Now + (QueueIntervalSeconds / 86400#)
+        End If
+    End If
+    task.Save
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "EnsureHiddenTask", Err, "task=" & taskName
+End Sub
+
+Public Sub RequestQueuePulse()
+    On Error GoTo CleanFail
+    Dim nextDue As Date
+    nextDue = Now + (QueueIntervalSeconds / 86400#)
+    If m_nextQueuePulse = 0# Or nextDue < m_nextQueuePulse - (QueueIntervalSeconds / 86400#) Then
+        UpdateQueuePulseReminder nextDue
+    End If
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "RequestQueuePulse", Err, ""
+End Sub
+
+Public Sub UpdateHourlyReminder()
+    On Error GoTo CleanFail
+    Dim session As Outlook.NameSpace
+    Set session = Application.Session
+    Dim task As Outlook.TaskItem
+    Set task = FindHiddenTask(HourlyTaskName)
+    If task Is Nothing Then
+        EnsureHiddenTask HourlyTaskName, True
+        Set task = FindHiddenTask(HourlyTaskName)
+    End If
+    If Not task Is Nothing Then
+        task.ReminderTime = DateAdd("h", 1, Now)
+        task.Save
+    End If
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "UpdateHourlyReminder", Err, ""
+End Sub
+
+Private Sub UpdateQueuePulseReminder(ByVal reminderTime As Date)
+    On Error GoTo CleanFail
+    Dim task As Outlook.TaskItem
+    Set task = FindHiddenTask(QueueTaskName)
+    If task Is Nothing Then
+        EnsureHiddenTask QueueTaskName, False
+        Set task = FindHiddenTask(QueueTaskName)
+    End If
+    If Not task Is Nothing Then
+        task.ReminderTime = reminderTime
+        task.Save
+        m_nextQueuePulse = reminderTime
+    End If
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "UpdateQueuePulseReminder", Err, ""
+End Sub
+
+Private Function FindHiddenTask(ByVal taskName As String) As Outlook.TaskItem
+    On Error GoTo CleanFail
+    Dim tasks As Outlook.MAPIFolder
+    Set tasks = Application.Session.GetDefaultFolder(olFolderTasks)
+    Dim items As Outlook.Items
+    Set items = tasks.Items
+    Dim index As Long
+    For index = 1 To items.Count
+        If TypeOf items(index) Is Outlook.TaskItem Then
+            Dim candidate As Outlook.TaskItem
+            Set candidate = items(index)
+            If StrComp(candidate.Subject, taskName, vbTextCompare) = 0 Then
+                Set FindHiddenTask = candidate
+                Exit Function
+            End If
+        End If
+    Next index
+    Exit Function
+CleanFail:
+    modHVDC_Logging.LogException "FindHiddenTask", Err, "task=" & taskName
+End Function
+
+Public Function ResolveWatchedFolders(ByVal session As Outlook.NameSpace) As Collection
+    On Error GoTo CleanFail
+    Dim result As Collection
+    Set result = New Collection
+
+    Dim seen As Object
+    Set seen = CreateObject("Scripting.Dictionary")
+    seen.CompareMode = vbTextCompare
+
+    Dim inbox As Outlook.MAPIFolder
+    Set inbox = session.GetDefaultFolder(olFolderInbox)
+    If Not inbox Is Nothing Then
+        result.Add inbox
+        seen.Add inbox.FolderPath, True
+    End If
+
+    Dim specs As Variant
+    Dim spec As Variant
+    If Len(Trim$(ADDITIONAL_FOLDERS)) > 0 Then
+        specs = Split(ADDITIONAL_FOLDERS, "|")
+        For Each spec In specs
+            Dim folder As Outlook.MAPIFolder
+            Set folder = ResolveFolderPath(session, CStr(spec))
+            If Not folder Is Nothing Then
+                If Not seen.Exists(folder.FolderPath) Then
+                    result.Add folder
+                    seen.Add folder.FolderPath, True
+                End If
+            End If
+        Next spec
+    End If
+
+    Set ResolveWatchedFolders = result
+    Exit Function
+CleanFail:
+    modHVDC_Logging.LogException "ResolveWatchedFolders", Err, ""
+End Function
+
+Public Function ResolveFolderPath(ByVal session As Outlook.NameSpace, ByVal relativePath As String) As Outlook.MAPIFolder
+    On Error GoTo CleanFail
+    Dim cleanPath As String
+    cleanPath = Trim$(relativePath)
+    If Len(cleanPath) = 0 Then
+        Exit Function
+    End If
+
+    Dim segments As Variant
+    segments = Split(cleanPath, "\\")
+
+    Dim currentFolder As Outlook.MAPIFolder
+    Set currentFolder = session.GetDefaultFolder(olFolderInbox)
+    Dim idx As Long
+    For idx = LBound(segments) To UBound(segments)
+        Dim nameSegment As String
+        nameSegment = Trim$(segments(idx))
+        If Len(nameSegment) = 0 Then
+            GoTo CleanFail
+        End If
+        If idx = LBound(segments) Then
+            If StrComp(nameSegment, currentFolder.Name, vbTextCompare) = 0 Then
+                GoTo ContinueLoop
+            End If
+        End If
+        If currentFolder Is Nothing Then Exit Function
+        If currentFolder.Folders.Count = 0 Then Exit Function
+        On Error Resume Next
+        Set currentFolder = currentFolder.Folders(nameSegment)
+        If Err.Number <> 0 Then
+            On Error GoTo CleanFail
+            Exit Function
+        End If
+        On Error GoTo CleanFail
+        If currentFolder Is Nothing Then
+            Exit Function
+        End If
+ContinueLoop:
+    Next idx
+    Set ResolveFolderPath = currentFolder
+    Exit Function
+CleanFail:
+    On Error Resume Next
+    modHVDC_Logging.LogException "ResolveFolderPath", Err, "path=" & relativePath
+End Function
+
+Public Sub RefreshQueuePulse()
+    RequestQueuePulse
+End Sub
+

--- a/outlook_vba/Modules/modHVDC_Export.bas
+++ b/outlook_vba/Modules/modHVDC_Export.bas
@@ -1,0 +1,245 @@
+Attribute VB_Name = "modHVDC_Export"
+Option Explicit
+
+Public Type HVDCBatchStats
+    ProcessedCount As Double
+    ExportedCount As Double
+    SkippedCount As Double
+    ErrorCount As Double
+    LatencyTotalMs As Double
+End Type
+
+Public Sub ResetBatchStats(ByRef stats As HVDCBatchStats)
+    stats.ProcessedCount = 0
+    stats.ExportedCount = 0
+    stats.SkippedCount = 0
+    stats.ErrorCount = 0
+    stats.LatencyTotalMs = 0
+End Sub
+
+Public Sub ProcessMailItem(ByVal mail As Outlook.MailItem, ByRef stats As HVDCBatchStats)
+    On Error GoTo CleanFail
+    Dim entryId As String
+    entryId = mail.EntryID
+    If Len(entryId) = 0 Then
+        entryId = "missing-entry-" & Format$(Now, "yyyymmddhhnnss")
+    End If
+
+    stats.ProcessedCount = stats.ProcessedCount + 1
+
+    Dim cache As Object
+    Set cache = modHVDC_Config.HVDCProcessedCache
+    If cache.Exists(entryId) Then
+        stats.SkippedCount = stats.SkippedCount + 1
+        Exit Sub
+    End If
+
+    Dim messagePath As String
+    messagePath = modHVDC_FileIO.ComposeMessageFilePath(mail)
+    Dim datedFolder As String
+    Dim folderIndex As Long
+    folderIndex = InStrRev(messagePath, "\")
+    If folderIndex > 0 Then
+        datedFolder = Left$(messagePath, folderIndex - 1)
+    Else
+        datedFolder = modHVDC_Config.HVDCExportRoot
+    End If
+
+    If Dir$(messagePath) <> "" Then
+        cache.Add entryId, True
+        stats.SkippedCount = stats.SkippedCount + 1
+        Exit Sub
+    End If
+
+    If Not modHVDC_FileIO.SaveMailItem(mail, messagePath) Then
+        stats.ErrorCount = stats.ErrorCount + 1
+        Exit Sub
+    End If
+
+    Dim attachmentsJson As String
+    attachmentsJson = SerializeAttachments(mail, entryId, datedFolder)
+
+    Dim metadataPath As String
+    metadataPath = modHVDC_FileIO.ComposeMetadataFilePath(messagePath)
+    Dim metadataJson As String
+    metadataJson = BuildMetadataJson(mail, messagePath, attachmentsJson)
+    modHVDC_FileIO.WriteJsonMetadata metadataJson, metadataPath
+
+    If Not cache.Exists(entryId) Then
+        cache.Add entryId, True
+    End If
+
+    stats.ExportedCount = stats.ExportedCount + 1
+    stats.LatencyTotalMs = stats.LatencyTotalMs + ComputeLatencyMs(mail.ReceivedTime)
+    Exit Sub
+CleanFail:
+    stats.ErrorCount = stats.ErrorCount + 1
+    modHVDC_Logging.LogException "ProcessMailItem", Err, "entry=" & entryId
+End Sub
+
+Public Sub RunCatchUp()
+    On Error GoTo CleanFail
+    Dim stats As HVDCBatchStats
+    ResetBatchStats stats
+
+    Dim session As Outlook.NameSpace
+    Set session = Application.Session
+
+    Dim folders As Collection
+    Set folders = modHVDC_Config.ResolveWatchedFolders(session)
+
+    Dim checkpoint As Date
+    checkpoint = modHVDC_FileIO.ReadCheckpointTimestamp
+
+    Dim folder As Outlook.MAPIFolder
+    For Each folder In folders
+        ProcessCatchUpFolder folder, checkpoint, stats
+    Next folder
+
+    modHVDC_FileIO.WriteCheckpointTimestamp Now
+    modHVDC_FileIO.PersistProcessedCache modHVDC_Config.HVDCProcessedCache
+    modHVDC_Logging.LogBatchStats stats, "CatchUp"
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "RunCatchUp", Err, ""
+End Sub
+
+Private Sub ProcessCatchUpFolder(ByVal folder As Outlook.MAPIFolder, ByVal sinceTime As Date, ByRef stats As HVDCBatchStats)
+    On Error GoTo CleanFail
+    Dim items As Outlook.Items
+    Set items = folder.Items
+    If items Is Nothing Then Exit Sub
+
+    items.IncludeRecurrences = False
+    items.Sort "[ReceivedTime]", True
+
+    Dim filter As String
+    filter = "[ReceivedTime] >= '" & Format$(sinceTime - (1 / 1440#), "yyyy-mm-dd hh:nn") & "'"
+    Dim recent As Outlook.Items
+    Set recent = items.Restrict(filter)
+    If recent Is Nothing Then Exit Sub
+
+    Dim index As Long
+    For index = 1 To recent.Count
+        If TypeOf recent(index) Is Outlook.MailItem Then
+            Dim mail As Outlook.MailItem
+            Set mail = recent(index)
+            ProcessMailItem mail, stats
+            Set mail = Nothing
+        End If
+        If (index Mod modHVDC_Config.BatchSizeLimit) = 0 Then
+            DoEvents
+        End If
+    Next index
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "ProcessCatchUpFolder", Err, folder.FolderPath
+End Sub
+
+Private Function SerializeAttachments(ByVal mail As Outlook.MailItem, ByVal entryId As String, ByVal datedFolder As String) As String
+    On Error GoTo CleanFail
+    Dim attachments As Outlook.Attachments
+    Set attachments = mail.Attachments
+    If attachments Is Nothing Or attachments.Count = 0 Then
+        SerializeAttachments = "[]"
+        Exit Function
+    End If
+
+    Dim attachmentFolder As String
+    attachmentFolder = modHVDC_FileIO.ComposeAttachmentsFolder(entryId, datedFolder)
+
+    Dim builder As String
+    builder = "["
+    Dim index As Long
+    For index = 1 To attachments.Count
+        Dim attachment As Outlook.Attachment
+        Set attachment = attachments(index)
+        Dim savedPath As String
+        savedPath = modHVDC_FileIO.SaveAttachment(attachment, attachmentFolder)
+        If Len(savedPath) > 0 Then
+            If Len(builder) > 1 Then
+                builder = builder & ","
+            End If
+            builder = builder & "{""name"":""" & JsonEscape(attachment.FileName) & """,""path"":""" & JsonEscape(savedPath) & """,""size"":""" & Format$(attachment.Size, "0.00") & """}"
+        End If
+        Set attachment = Nothing
+    Next index
+    builder = builder & "]"
+    SerializeAttachments = builder
+    Exit Function
+CleanFail:
+    modHVDC_Logging.LogException "SerializeAttachments", Err, entryId
+    SerializeAttachments = "[]"
+End Function
+Private Function BuildMetadataJson(ByVal mail As Outlook.MailItem, ByVal messagePath As String, ByVal attachmentsJson As String) As String
+    Const DQ As String = Chr$(34)
+    Dim receivedLocal As String
+    If mail.ReceivedTime = 0 Then
+        receivedLocal = Format$(Now, "yyyy-mm-dd\THH:nn:ss")
+    Else
+        receivedLocal = Format$(mail.ReceivedTime, "yyyy-mm-dd\THH:nn:ss")
+    End If
+    Dim receivedUtc As String
+    receivedUtc = receivedLocal
+
+    Dim payload As String
+    payload = "{" & DQ & "entry_id" & DQ & ":" & DQ & JsonEscape(mail.EntryID) & DQ
+    payload = payload & "," & DQ & "subject" & DQ & ":" & DQ & JsonEscape(mail.Subject) & DQ
+    payload = payload & "," & DQ & "sender_name" & DQ & ":" & DQ & JsonEscape(mail.SenderName) & DQ
+    payload = payload & "," & DQ & "sender_address" & DQ & ":" & DQ & JsonEscape(mail.SenderEmailAddress) & DQ
+    payload = payload & "," & DQ & "received_local" & DQ & ":" & DQ & receivedLocal & DQ
+    payload = payload & "," & DQ & "received_utc" & DQ & ":" & DQ & receivedUtc & DQ
+    payload = payload & "," & DQ & "message_path" & DQ & ":" & DQ & JsonEscape(messagePath) & DQ
+    payload = payload & "," & DQ & "to" & DQ & ":" & SerializeRecipients(mail, olTo)
+    payload = payload & "," & DQ & "cc" & DQ & ":" & SerializeRecipients(mail, olCC)
+    payload = payload & "," & DQ & "bcc" & DQ & ":" & SerializeRecipients(mail, olBCC)
+    payload = payload & "," & DQ & "attachments" & DQ & ":" & attachmentsJson & "}"
+    BuildMetadataJson = payload
+End Function
+
+Private Function SerializeRecipients(ByVal mail As Outlook.MailItem, ByVal recipientType As Outlook.OlMailRecipientType) As String
+    On Error GoTo CleanFail
+    Dim recipients As Outlook.Recipients
+    Set recipients = mail.Recipients
+    If recipients Is Nothing Then
+        SerializeRecipients = "[]"
+        Exit Function
+    End If
+    Dim builder As String
+    builder = "["
+    Dim index As Long
+    For index = 1 To recipients.Count
+        Dim recipient As Outlook.Recipient
+        Set recipient = recipients(index)
+        If recipient.Type = recipientType Then
+            If Len(builder) > 1 Then
+                builder = builder & ","
+            End If
+            builder = builder & "{""name"":""" & JsonEscape(recipient.Name) & """,""address"":""" & JsonEscape(recipient.Address) & """}"
+        End If
+        Set recipient = Nothing
+    Next index
+    builder = builder & "]"
+    SerializeRecipients = builder
+    Exit Function
+CleanFail:
+    modHVDC_Logging.LogException "SerializeRecipients", Err, ""
+    SerializeRecipients = "[]"
+End Function
+
+Private Function JsonEscape(ByVal value As String) As String
+    Dim sanitized As String
+    sanitized = Replace(value, "\", "\\")
+    sanitized = Replace(sanitized, """", "\"")
+    sanitized = Replace(sanitized, vbCr, "\r")
+    sanitized = Replace(sanitized, vbLf, "\n")
+    JsonEscape = sanitized
+End Function
+
+Private Function ComputeLatencyMs(ByVal receivedTime As Date) As Double
+    If receivedTime = 0 Then
+        ComputeLatencyMs = 0
+    Else
+        ComputeLatencyMs = (Now - receivedTime) * 86400000#
+    End If
+End Function

--- a/outlook_vba/Modules/modHVDC_FileIO.bas
+++ b/outlook_vba/Modules/modHVDC_FileIO.bas
@@ -1,0 +1,420 @@
+Attribute VB_Name = "modHVDC_FileIO"
+Option Explicit
+
+Private Const TEMP_PREFIX As String = "hvdc_tmp_"
+
+Public Function JoinPath(ByVal parentPath As String, ByVal childPath As String) As String
+    Dim trimmedParent As String
+    Dim trimmedChild As String
+    trimmedParent = Trim$(parentPath)
+    trimmedChild = Trim$(childPath)
+
+    If Len(trimmedParent) = 0 Then
+        JoinPath = trimmedChild
+        Exit Function
+    End If
+
+    If Len(trimmedChild) = 0 Then
+        JoinPath = trimmedParent
+        Exit Function
+    End If
+
+    If Right$(trimmedParent, 1) = "\" Or Right$(trimmedParent, 1) = "/" Then
+        trimmedParent = Left$(trimmedParent, Len(trimmedParent) - 1)
+    End If
+
+    If Left$(trimmedChild, 1) = "\" Or Left$(trimmedChild, 1) = "/" Then
+        trimmedChild = Mid$(trimmedChild, 2)
+    End If
+
+    JoinPath = trimmedParent & "\" & trimmedChild
+End Function
+
+Public Sub EnsureFolderExists(ByVal targetPath As String)
+    On Error GoTo CleanFail
+    Dim fso As Object
+    Set fso = CreateObject("Scripting.FileSystemObject")
+    If Len(Trim$(targetPath)) = 0 Then Exit Sub
+    If Not fso.FolderExists(targetPath) Then
+        Dim parentPath As String
+        parentPath = fso.GetParentFolderName(targetPath)
+        If Len(parentPath) > 0 And Not fso.FolderExists(parentPath) Then
+            EnsureFolderExists parentPath
+        End If
+        fso.CreateFolder targetPath
+    End If
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "EnsureFolderExists", Err, targetPath
+End Sub
+
+Public Function BuildDatedExportFolder(ByVal receivedTime As Date) As String
+    Dim safeTime As Date
+    If receivedTime = 0 Then
+        safeTime = Now
+    Else
+        safeTime = receivedTime
+    End If
+
+    Dim baseFolder As String
+    baseFolder = modHVDC_Config.HVDCExportRoot
+    Dim yearFolder As String
+    yearFolder = JoinPath(baseFolder, Format$(safeTime, "yyyy"))
+    EnsureFolderExists yearFolder
+
+    Dim monthFolder As String
+    monthFolder = JoinPath(yearFolder, Format$(safeTime, "mm"))
+    EnsureFolderExists monthFolder
+
+    Dim dayFolder As String
+    dayFolder = JoinPath(monthFolder, Format$(safeTime, "dd"))
+    EnsureFolderExists dayFolder
+
+    BuildDatedExportFolder = dayFolder
+End Function
+
+Public Function BuildMessageFileName(ByVal mail As Outlook.MailItem) As String
+    Dim safeTime As Date
+    If mail.ReceivedTime = 0 Then
+        safeTime = Now
+    Else
+        safeTime = mail.ReceivedTime
+    End If
+    Dim entryHash As String
+    entryHash = EntryIdHash(mail.EntryID)
+    BuildMessageFileName = Format$(safeTime, "yyyy-mm-dd_hh-nn-ss") & "_" & entryHash & ".msg"
+End Function
+
+Public Function ComposeMessageFilePath(ByVal mail As Outlook.MailItem) As String
+    Dim targetFolder As String
+    targetFolder = BuildDatedExportFolder(mail.ReceivedTime)
+    ComposeMessageFilePath = JoinPath(targetFolder, BuildMessageFileName(mail))
+End Function
+
+Public Function ComposeMetadataFilePath(ByVal messagePath As String) As String
+    ComposeMetadataFilePath = Left$(messagePath, Len(messagePath) - 4) & ".json"
+End Function
+
+Public Function ComposeAttachmentsFolder(ByVal entryId As String, ByVal datedFolder As String) As String
+    Dim attachmentsRoot As String
+    attachmentsRoot = JoinPath(datedFolder, "attachments")
+    EnsureFolderExists attachmentsRoot
+    Dim folderName As String
+    folderName = SanitizeFolderName(entryId)
+    Dim finalFolder As String
+    finalFolder = JoinPath(attachmentsRoot, folderName)
+    EnsureFolderExists finalFolder
+    ComposeAttachmentsFolder = finalFolder
+End Function
+
+Public Function SaveMailItem(ByVal mail As Outlook.MailItem, ByVal targetPath As String) As Boolean
+    On Error GoTo CleanFail
+    Dim tempPath As String
+    tempPath = BuildTempFilePath(targetPath)
+    mail.SaveAs tempPath, olMSGUnicode
+    MoveWithRetry tempPath, targetPath
+    SaveMailItem = True
+    Exit Function
+CleanFail:
+    SaveMailItem = False
+    modHVDC_Logging.LogException "SaveMailItem", Err, targetPath
+    On Error Resume Next
+    If Len(Dir$(tempPath)) > 0 Then
+        Kill tempPath
+    End If
+End Function
+
+Public Function SaveAttachment(ByVal attachment As Outlook.Attachment, ByVal targetFolder As String) As String
+    On Error GoTo CleanFail
+    Dim sanitizedName As String
+    sanitizedName = SanitizeFileName(attachment.FileName)
+    Dim finalPath As String
+    finalPath = JoinPath(targetFolder, sanitizedName)
+    Dim tempPath As String
+    tempPath = BuildTempFilePath(finalPath)
+    attachment.SaveAsFile tempPath
+    MoveWithRetry tempPath, finalPath
+    SaveAttachment = finalPath
+    Exit Function
+CleanFail:
+    modHVDC_Logging.LogException "SaveAttachment", Err, targetFolder
+    SaveAttachment = ""
+    On Error Resume Next
+    If Len(tempPath) > 0 And Dir$(tempPath) <> "" Then
+        Kill tempPath
+    End If
+End Function
+
+Public Sub WriteJsonMetadata(ByVal jsonContent As String, ByVal targetPath As String)
+    On Error GoTo CleanFail
+    WriteTextAtomic targetPath, jsonContent
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "WriteJsonMetadata", Err, targetPath
+End Sub
+
+Public Sub WriteTextAtomic(ByVal targetPath As String, ByVal content As String)
+    On Error GoTo CleanFail
+    Dim tempPath As String
+    tempPath = BuildTempFilePath(targetPath)
+
+    Dim handle As Integer
+    handle = FreeFile
+    Open tempPath For Output As #handle
+    Print #handle, content
+    Close #handle
+
+    MoveWithRetry tempPath, targetPath
+    Exit Sub
+CleanFail:
+    On Error Resume Next
+    If handle <> 0 Then Close #handle
+    If Len(tempPath) > 0 And Dir$(tempPath) <> "" Then Kill tempPath
+    modHVDC_Logging.LogException "WriteTextAtomic", Err, targetPath
+End Sub
+
+Public Function ReadAllText(ByVal sourcePath As String) As String
+    On Error GoTo CleanFail
+    If Dir$(sourcePath) = "" Then
+        Exit Function
+    End If
+    Dim handle As Integer
+    handle = FreeFile
+    Open sourcePath For Input As #handle
+    ReadAllText = Input$(LOF(handle), handle)
+    Close #handle
+    Exit Function
+CleanFail:
+    On Error Resume Next
+    If handle <> 0 Then Close #handle
+    modHVDC_Logging.LogException "ReadAllText", Err, sourcePath
+End Function
+
+Public Function ReadCheckpointTimestamp() As Date
+    On Error GoTo CleanFail
+    Dim rawText As String
+    rawText = ReadAllText(modHVDC_Config.HVDCCheckpointFile)
+    If Len(Trim$(rawText)) = 0 Then
+        ReadCheckpointTimestamp = CDate("1970-01-01 00:00:00")
+        Exit Function
+    End If
+    Dim marker As String
+    marker = "last_processed"
+    Dim position As Long
+    position = InStr(1, rawText, marker, vbTextCompare)
+    If position = 0 Then
+        ReadCheckpointTimestamp = CDate("1970-01-01 00:00:00")
+        Exit Function
+    End If
+    Dim startQuote As Long
+    startQuote = InStr(position, rawText, ":", vbTextCompare)
+    If startQuote = 0 Then
+        ReadCheckpointTimestamp = CDate("1970-01-01 00:00:00")
+        Exit Function
+    End If
+    startQuote = InStr(startQuote, rawText, """", vbTextCompare)
+    If startQuote = 0 Then
+        ReadCheckpointTimestamp = CDate("1970-01-01 00:00:00")
+        Exit Function
+    End If
+    Dim endQuote As Long
+    endQuote = InStr(startQuote + 1, rawText, """", vbTextCompare)
+    If endQuote = 0 Then
+        ReadCheckpointTimestamp = CDate("1970-01-01 00:00:00")
+        Exit Function
+    End If
+    Dim isoValue As String
+    isoValue = Mid$(rawText, startQuote + 1, endQuote - startQuote - 1)
+    ReadCheckpointTimestamp = CDate(Replace(Mid$(isoValue, 1, 19), "T", " "))
+    Exit Function
+CleanFail:
+    modHVDC_Logging.LogException "ReadCheckpointTimestamp", Err, ""
+    ReadCheckpointTimestamp = CDate("1970-01-01 00:00:00")
+End Function
+
+Public Sub WriteCheckpointTimestamp(ByVal timestampValue As Date)
+    On Error GoTo CleanFail
+    Dim isoValue As String
+    isoValue = Format$(timestampValue, "yyyy-mm-dd\THH:nn:ss")
+    Dim jsonContent As String
+    jsonContent = "{""last_processed"":""" & isoValue & """}"
+    WriteTextAtomic modHVDC_Config.HVDCCheckpointFile, jsonContent
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "WriteCheckpointTimestamp", Err, ""
+End Sub
+
+Public Sub EnsureCheckpointFile(ByVal checkpointPath As String)
+    On Error GoTo CleanFail
+    If Dir$(checkpointPath) = "" Then
+        WriteCheckpointTimestamp CDate("1970-01-01 00:00:00")
+    End If
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "EnsureCheckpointFile", Err, checkpointPath
+End Sub
+
+Public Sub LoadProcessedCache(ByVal cache As Object)
+    On Error GoTo CleanFail
+    Dim cachePath As String
+    cachePath = modHVDC_Config.HVDCProcessedCacheFile
+    If Dir$(cachePath) = "" Then
+        Exit Sub
+    End If
+    Dim raw As String
+    raw = ReadAllText(cachePath)
+    If Len(raw) = 0 Then Exit Sub
+    Dim lines As Variant
+    lines = Split(raw, vbCrLf)
+    Dim line As Variant
+    For Each line In lines
+        Dim trimmed As String
+        trimmed = Trim$(CStr(line))
+        If Len(trimmed) > 0 Then
+            If Not cache.Exists(trimmed) Then
+                cache.Add trimmed, True
+            End If
+        End If
+    Next line
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "LoadProcessedCache", Err, cachePath
+End Sub
+
+Public Sub PersistProcessedCache(ByVal cache As Object)
+    On Error GoTo CleanFail
+    Dim cachePath As String
+    cachePath = modHVDC_Config.HVDCProcessedCacheFile
+    Dim builder As String
+    Dim key As Variant
+    For Each key In cache.Keys
+        builder = builder & CStr(key) & vbCrLf
+    Next key
+    WriteTextAtomic cachePath, builder
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "PersistProcessedCache", Err, cachePath
+End Sub
+
+Private Sub MoveWithRetry(ByVal sourcePath As String, ByVal targetPath As String)
+    On Error GoTo CleanFail
+    Dim fso As Object
+    Set fso = CreateObject("Scripting.FileSystemObject")
+    Dim attempt As Long
+    Dim delayMs As Long
+    delayMs = 50
+    For attempt = 1 To 5
+        On Error Resume Next
+        If fso.FileExists(targetPath) Then
+            fso.DeleteFile targetPath, True
+        End If
+        On Error GoTo RetryFailure
+        fso.MoveFile sourcePath, targetPath
+        Exit For
+RetryFailure:
+        On Error GoTo CleanFail
+        If attempt = 5 Then
+            Err.Raise vbObjectError + 513, "MoveWithRetry", "Unable to move file after retries"
+        End If
+        SleepMilliseconds delayMs
+        delayMs = delayMs * 2
+    Next attempt
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "MoveWithRetry", Err, targetPath
+    On Error Resume Next
+    If fso.FileExists(sourcePath) Then
+        fso.DeleteFile sourcePath, True
+    End If
+End Sub
+
+Private Function BuildTempFilePath(ByVal targetPath As String) As String
+    Dim fso As Object
+    Set fso = CreateObject("Scripting.FileSystemObject")
+    Dim tempFolder As String
+    tempFolder = Environ$("TEMP")
+    If Len(tempFolder) = 0 Then
+        tempFolder = modHVDC_Config.HVDCStatePath
+    End If
+    EnsureFolderExists tempFolder
+    Dim tempName As String
+    tempName = TEMP_PREFIX & CStr(Timer * 1000#) & "_" & EntryIdHash(targetPath) & ".tmp"
+    BuildTempFilePath = JoinPath(tempFolder, tempName)
+End Function
+
+Private Sub SleepMilliseconds(ByVal durationMs As Long)
+    Dim endTick As Single
+    endTick = Timer + (durationMs / 1000#)
+    Do While Timer < endTick
+        DoEvents
+    Loop
+End Sub
+
+Public Function SanitizeFileName(ByVal candidate As String) As String
+    Dim sanitized As String
+    sanitized = candidate
+    sanitized = Replace(sanitized, "\", "_")
+    sanitized = Replace(sanitized, "/", "_")
+    sanitized = Replace(sanitized, ":", "_")
+    sanitized = Replace(sanitized, "*", "_")
+    sanitized = Replace(sanitized, "?", "_")
+    sanitized = Replace(sanitized, """", "_")
+    sanitized = Replace(sanitized, "<", "_")
+    sanitized = Replace(sanitized, ">", "_")
+    sanitized = Replace(sanitized, "|", "_")
+    If Len(sanitized) = 0 Then
+        sanitized = "attachment.bin"
+    End If
+    SanitizeFileName = sanitized
+End Function
+
+Private Function SanitizeFolderName(ByVal candidate As String) As String
+    Dim sanitized As String
+    sanitized = SanitizeFileName(candidate)
+    If Len(sanitized) > 60 Then
+        sanitized = Left$(sanitized, 60)
+    End If
+    SanitizeFolderName = sanitized
+End Function
+
+Public Function EntryIdHash(ByVal value As String) As String
+    Dim table As Variant
+    table = Crc32Table()
+    Dim crc As Long
+    crc = &HFFFFFFFF
+    Dim idx As Long
+    For idx = 1 To Len(value)
+        Dim byteValue As Long
+        byteValue = Asc(Mid$(value, idx, 1)) And &HFF&
+        crc = ((crc And &HFFFFFF00) \ &H100) Xor table((crc Xor byteValue) And &HFF&)
+    Next idx
+    crc = Not crc
+    EntryIdHash = Right$("00000000" & Hex$(crc And &HFFFFFFFF), 8)
+End Function
+
+Private Function Crc32Table() As Variant
+    Static table As Variant
+    If IsEmpty(table) Then
+        Dim poly As Long
+        poly = &HEDB88320
+        ReDim table(0 To 255)
+
+        Dim i As Long
+        Dim j As Long
+        Dim crc As Long
+
+        For i = 0 To 255
+            crc = i
+            For j = 0 To 7
+                If (crc And 1) <> 0 Then
+                    crc = (crc \ 2) Xor poly
+                Else
+                    crc = crc \ 2
+                End If
+            Next j
+            table(i) = crc And &HFFFFFFFF
+        Next i
+    End If
+    Crc32Table = table
+End Function
+

--- a/outlook_vba/Modules/modHVDC_Logging.bas
+++ b/outlook_vba/Modules/modHVDC_Logging.bas
@@ -1,0 +1,128 @@
+Attribute VB_Name = "modHVDC_Logging"
+Option Explicit
+
+Private Const LOG_FILE_BASENAME As String = "hvdc_pipeline.log"
+
+Public Sub LogEvent(ByVal level As String, ByVal message As String, Optional ByVal context As String = "")
+    On Error GoTo CleanFail
+    If Not modHVDC_Config.LoggingEnabled Then
+        Exit Sub
+    End If
+
+    Dim logFile As String
+    logFile = modHVDC_FileIO.JoinPath(modHVDC_Config.HVDCLogPath, LOG_FILE_BASENAME)
+
+    modHVDC_FileIO.EnsureFolderExists modHVDC_Config.HVDCLogPath
+    RotateLogsIfNeeded logFile
+
+    Dim handle As Integer
+    handle = FreeFile
+    Open logFile For Append As #handle
+    Print #handle, BuildLogLine(level, message, context)
+    Close #handle
+    Exit Sub
+CleanFail:
+    On Error Resume Next
+    If handle <> 0 Then Close #handle
+End Sub
+
+Public Sub LogInfo(ByVal message As String, Optional ByVal context As String = "")
+    LogEvent "INFO", message, context
+End Sub
+
+Public Sub LogWarn(ByVal message As String, Optional ByVal context As String = "")
+    LogEvent "WARN", message, context
+End Sub
+
+Public Sub LogError(ByVal message As String, Optional ByVal context As String = "")
+    LogEvent "ERROR", message, context
+End Sub
+
+Public Sub LogException(ByVal procName As String, ByVal ex As ErrObject, Optional ByVal context As String = "")
+    On Error Resume Next
+    Dim payload As String
+    payload = "{""procedure"":""" & JsonEscape(procName) & """,""number"":""" & Format$(ex.Number, "0") & """,""description"":""" & JsonEscape(ex.Description) & """"}
+    LogEvent "ERROR", "Unhandled exception", MergeContext(context, payload)
+End Sub
+
+Public Sub LogBatchStats(ByRef stats As HVDCBatchStats, ByVal context As String)
+    On Error GoTo CleanFail
+    Dim avgLatency As Double
+    If stats.ProcessedCount > 0 Then
+        avgLatency = stats.LatencyTotalMs / stats.ProcessedCount
+    Else
+        avgLatency = 0#
+    End If
+    Dim payload As String
+    payload = "{""processed"":""" & Format$(stats.ProcessedCount, "0.00") & """,""exported"":""" & Format$(stats.ExportedCount, "0.00") & """,""skipped"":""" & Format$(stats.SkippedCount, "0.00") & """,""errors"":""" & Format$(stats.ErrorCount, "0.00") & """,""avg_latency_ms"":""" & Format$(avgLatency, "0.00") & """"}
+    LogEvent "METRIC", context, payload
+    Exit Sub
+CleanFail:
+    LogException "LogBatchStats", Err, context
+End Sub
+
+Private Function BuildLogLine(ByVal level As String, ByVal message As String, ByVal context As String) As String
+    Dim ts As String
+    ts = Format$(Now, "yyyy-mm-dd\THH:nn:ss")
+    Dim line As String
+    line = "{""timestamp"":""" & ts & """,""level"":""" & JsonEscape(UCase$(level)) & """,""message"":""" & JsonEscape(message) & """"
+    If Len(Trim$(context)) > 0 Then
+        line = line & ",""context"":" & context
+    End If
+    line = line & "}"
+    BuildLogLine = line
+End Function
+
+Private Sub RotateLogsIfNeeded(ByVal activeFile As String)
+    On Error GoTo CleanFail
+    If Dir$(activeFile) = "" Then
+        Exit Sub
+    End If
+    If FileLen(activeFile) < modHVDC_Config.LogMaxSizeBytes Then
+        Exit Sub
+    End If
+
+    Dim limit As Long
+    limit = modHVDC_Config.LogFileLimit
+
+    Dim index As Long
+    For index = limit - 1 To 1 Step -1
+        Dim sourceFile As String
+        sourceFile = activeFile & "." & CStr(index)
+        If Dir$(sourceFile) <> "" Then
+            Name sourceFile As activeFile & "." & CStr(index + 1)
+        End If
+    Next index
+
+    Dim rotated As String
+    rotated = activeFile & ".1"
+    Name activeFile As rotated
+
+    Exit Sub
+CleanFail:
+    ' swallow rotation errors to avoid blocking pipeline
+End Sub
+
+Private Function JsonEscape(ByVal value As String) As String
+    Dim result As String
+    result = Replace(value, "\", "\\")
+    result = Replace(result, """", "\"")
+    result = Replace(result, vbCr, "\r")
+    result = Replace(result, vbLf, "\n")
+    JsonEscape = result
+End Function
+
+Private Function MergeContext(ByVal context As String, ByVal addition As String) As String
+    Dim trimmed As String
+    trimmed = Trim$(context)
+    If Len(trimmed) = 0 Then
+        MergeContext = addition
+    ElseIf Left$(trimmed, 1) = "{" And Right$(trimmed, 1) = "}" Then
+        MergeContext = "{" & Trim$(Mid$(trimmed, 2, Len(trimmed) - 2)) & "," & Trim$(Mid$(addition, 2, Len(addition) - 2)) & "}"
+    Else
+        Dim wrapped As String
+        wrapped = "{\"context\":\"" & JsonEscape(trimmed) & "\"}"
+        MergeContext = MergeContext(wrapped, addition)
+    End If
+End Function
+

--- a/outlook_vba/ThisOutlookSession.cls
+++ b/outlook_vba/ThisOutlookSession.cls
@@ -1,0 +1,139 @@
+VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = "ThisOutlookSession"
+Option Explicit
+
+Private m_watchers As Collection
+
+Private Sub Application_Startup()
+    On Error GoTo CleanFail
+    modHVDC_Config.InitializeHVDC
+    Set m_watchers = New Collection
+
+    Dim session As Outlook.NameSpace
+    Set session = Application.Session
+
+    Dim folders As Collection
+    Set folders = modHVDC_Config.ResolveWatchedFolders(session)
+
+    Dim folder As Outlook.MAPIFolder
+    For Each folder In folders
+        Dim watcher As clsHVDC_InboxWatcher
+        Set watcher = New clsHVDC_InboxWatcher
+        watcher.Initialise folder
+        m_watchers.Add watcher
+    Next folder
+
+    Dim context As String
+    context = "{""folder_count"":""" & Format$(folders.Count, "0.00") & """}"
+    modHVDC_Logging.LogInfo "HVDC automation ready", context
+    modHVDC_Config.RequestQueuePulse
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "Application_Startup", Err, ""
+End Sub
+
+Private Sub Application_Quit()
+    On Error Resume Next
+    Dim stats As HVDCBatchStats
+    modHVDC_Export.ResetBatchStats stats
+    Dim watcher As clsHVDC_InboxWatcher
+    If Not m_watchers Is Nothing Then
+        For Each watcher In m_watchers
+            watcher.FlushPending stats
+        Next watcher
+    End If
+    modHVDC_FileIO.PersistProcessedCache modHVDC_Config.HVDCProcessedCache
+    Set m_watchers = Nothing
+    modHVDC_Logging.LogInfo "HVDC automation stopped", "{}"
+End Sub
+
+Private Sub Application_NewMailEx(ByVal EntryIDCollection As String)
+    On Error GoTo CleanFail
+    Dim entries As Variant
+    entries = Split(EntryIDCollection, ",")
+    Dim index As Long
+    For index = LBound(entries) To UBound(entries)
+        NotifyWatchers Trim$(CStr(entries(index)))
+    Next index
+    modHVDC_Config.RequestQueuePulse
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "Application_NewMailEx", Err, ""
+End Sub
+
+Private Sub Application_Reminder(ByVal Item As Object)
+    On Error GoTo CleanFail
+    Dim subjectText As String
+    subjectText = ""
+    If Not Item Is Nothing Then
+        If TypeOf Item Is Outlook.TaskItem Then
+            subjectText = Item.Subject
+        Else
+            Exit Sub
+        End If
+    End If
+
+    If StrComp(subjectText, modHVDC_Config.QueueTaskName, vbTextCompare) = 0 Then
+        HandleQueuePulse
+    ElseIf StrComp(subjectText, modHVDC_Config.HourlyTaskName, vbTextCompare) = 0 Then
+        HandleHourlyCatchUp
+    End If
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "Application_Reminder", Err, ""
+End Sub
+
+Private Sub HandleQueuePulse()
+    On Error GoTo CleanFail
+    Dim stats As HVDCBatchStats
+    modHVDC_Export.ResetBatchStats stats
+
+    Dim watcher As clsHVDC_InboxWatcher
+    Dim pending As Boolean
+    pending = False
+    If Not m_watchers Is Nothing Then
+        For Each watcher In m_watchers
+            watcher.ProcessPending stats, modHVDC_Config.BatchSizeLimit
+            pending = pending Or watcher.HasPending
+        Next watcher
+    End If
+
+    If stats.ProcessedCount + stats.SkippedCount + stats.ErrorCount > 0 Then
+        modHVDC_Logging.LogBatchStats stats, "QueuePulse"
+        modHVDC_FileIO.PersistProcessedCache modHVDC_Config.HVDCProcessedCache
+    End If
+
+    If pending Then
+        modHVDC_Config.RequestQueuePulse
+    End If
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "HandleQueuePulse", Err, ""
+End Sub
+
+Private Sub HandleHourlyCatchUp()
+    On Error GoTo CleanFail
+    modHVDC_Export.RunCatchUp
+    modHVDC_Config.UpdateHourlyReminder
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "HandleHourlyCatchUp", Err, ""
+End Sub
+
+Private Sub NotifyWatchers(ByVal entryId As String)
+    On Error GoTo CleanFail
+    If Len(entryId) = 0 Then Exit Sub
+    Dim watcher As clsHVDC_InboxWatcher
+    If Not m_watchers Is Nothing Then
+        For Each watcher In m_watchers
+            watcher.NotifyEntry entryId
+        Next watcher
+    End If
+    Exit Sub
+CleanFail:
+    modHVDC_Logging.LogException "NotifyWatchers", Err, entryId
+End Sub
+


### PR DESCRIPTION
## Summary
- add a .gitattributes rule forcing .bas/.cls/.frm files to checkout with Windows CRLF endings
- document the fix for the VBA "Too many line continuations" import error and update the changelog

## Testing
- pytest -q
- coverage run -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8b2d665348327b2567fd66ace9ae4